### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/blockworkscom/86cde197-4084-4716-9cd6-fbab1f65081b/edd61b56-c9cd-4871-9dee-4dbab3f9db65/_apis/work/boardbadge/6b1b4f8e-c8ed-46a7-a285-0e39e55b9f98)](https://dev.azure.com/blockworkscom/86cde197-4084-4716-9cd6-fbab1f65081b/_boards/board/t/edd61b56-c9cd-4871-9dee-4dbab3f9db65/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/blockworkscom/86cde197-4084-4716-9cd6-fbab1f65081b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.